### PR TITLE
Remove redundant --std spec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
-
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)


### PR DESCRIPTION
ROS1の名残でしょうか？--std=c++11のフラグを付け加える設定を削除。

## トラブルシュートの過程
source /opt/ros/foxy/setup.sh && colcon build --event-handlers console_cohesion+ --packages-up-to color_names --symlink-install --cmake-args -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_CXX_STANDARD=11
を実行してみたところ手元環境で再現。

```
[0.705s] [ 25%] [32mBuilding CXX object CMakeFiles/color_names.dir/src/color_names.cpp.o[0m
[0.705s] /usr/bin/c++  -DDEFAULT_RMW_IMPLEMENTATION=rmw_fastrtps_cpp -DRCUTILS_ENABLE_FAULT_INJECTION -DSPDLOG_COMPILED_LIB -Dcolor_names_EXPORTS -I/home/ouxt/ouxt_automation/fixci_ws/src/color_names/include -isystem /opt/ros/foxy/include  -fPIC   -Wall -Wextra -Wpedantic -std=gnu++11 -o CMakeFiles/color_names.dir/src/color_names.cpp.o -c /home/ouxt/ouxt_automation/fixci_ws/src/color_names/src/color_names.cpp
[0.894s] In file included from [01m[K/opt/ros/foxy/include/std_msgs/msg/detail/color_rgba__struct.hpp:8[m[K,
[0.894s]                  from [01m[K/opt/ros/foxy/include/std_msgs/msg/color_rgba.hpp:7[m[K,
[0.894s]                  from [01m[K/home/ouxt/ouxt_automation/fixci_ws/src/color_names/include/color_names/color_names.hpp:25[m[K,
[0.894s]                  from [01m[K/home/ouxt/ouxt_automation/fixci_ws/src/color_names/src/color_names.cpp:15[m[K:
[0.894s] [01m[K/opt/ros/foxy/include/rosidl_runtime_cpp/bounded_vector.hpp:477:3:[m[K [01;31m[Kerror: [m[K‘[01m[Kemplace_back[m[K’ function uses ‘[01m[Kauto[m[K’ type specifier without trailing return type
```

と出力されたため、次は-DCMAKE_CXX_STANDARD=11を抜いて実行


```
[1.269s] /usr/bin/c++  -DDEFAULT_RMW_IMPLEMENTATION=rmw_fastrtps_cpp -DRCUTILS_ENABLE_FAULT_INJECTION -DSPDLOG_COMPILED_LIB -I/home/ouxt/ouxt_automation/fixci_ws/src/color_names/include -isystem /opt/ros/foxy/include  -Wall -Wextra -Wpedantic -std=c++11 -std=gnu++14 -o CMakeFiles/view_all.dir/src/view_all.cpp.o -c /home/ouxt/ouxt_automation/fixci_ws/src/color_names/src/view_all.cpp
```

だったので、２つのstdがあることによる解釈依存のエラーと気づく。